### PR TITLE
Navigation back/forward in IntelliJ

### DIFF
--- a/intellij-shortkeys.md
+++ b/intellij-shortkeys.md
@@ -27,6 +27,8 @@ The most useful IntelliJ shortcuts that I use everyday
 | cmd + [ or ]         | undo / redo last navigation operation                 |
 | fn + up or down arrow| page up / down                                        |
 | cmd + opt + [ or ]   | move caret to code block start/end, a.k.a { and }     |
+| cmd + opt + Left     | Navigate back to previous view location               |
+| cmd + opt + Right    | Navigate forward to next view location                |
 
 # Search and Replace
 | Shortcut        | Comment                 |


### PR DESCRIPTION
These shortcuts allow to navigate in different views easily. For example, I'm editing a method and I see a constant used. I'm curious about the definition of this constant, so I navigate to that constant. Once I understand it, I would like to go back to method to continue my edition. In shortcuts, these actions can be done as follows:

1. See the declaration of the constant (cmd + B)
2. Go back to method (cmd + opt + left)
3. Go forward to declaration again (cmd + opt + right)