### PR TITLE
Delete inner word

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -7,21 +7,22 @@ Open Vim to a specific line, e.g. line 42:
     vim +42 myFile
 
 ## Navigation
-Command | Description
-:--- | :---
-`:42` | Go to line 42
-`0` | Move to beginning of the current line
-`$` | Move to end of the current line
-<kbd>⌃</kbd> + <kbd>U</kbd> | Move up half of the page
-<kbd>⌃</kbd> + <kbd>D</kbd> | Move down half of the page
-`w` | Cursor one word forward
-`b` | Cursor one word back
+| Command                     | Description                           |
+| :-------------------------- | :------------------------------------ |
+| `:42`                       | Go to line 42                         |
+| `0`                         | Move to beginning of the current line |
+| `$`                         | Move to end of the current line       |
+| <kbd>⌃</kbd> + <kbd>U</kbd> | Move up half of the page              |
+| <kbd>⌃</kbd> + <kbd>D</kbd> | Move down half of the page            |
+| `w`                         | Cursor one word forward               |
+| `b`                         | Cursor one word back                  |
 
 
 ## Editing
-Command | Description
-:--- | :---
-`ddp` | Swap the current line with the next. Useful for re-organizing commits in e.p. `git rebase -i HEAD~5`
-`ddkkp` | Swap the current line with the previous
-`u` | Undo
-`:%s/\t/  /g` | Replace tab by 2 spaces in the current editor.
+| Command       | Description                                                                                          |
+| :------------ | :--------------------------------------------------------------------------------------------------- |
+| `ddp`         | Swap the current line with the next. Useful for re-organizing commits in e.p. `git rebase -i HEAD~5` |
+| `ddkkp`       | Swap the current line with the previous                                                              |
+| `u`           | Undo                                                                                                 |
+| `:%s/\t/  /g` | Replace tab by 2 spaces in the current editor.                                                       |
+| `diw`         | (delete inner word). Delete a word when the cursor is on it                                          |


### PR DESCRIPTION
Useful when the cursor is on the first character or in the middle of the word and you want to delete the whole word. In fact, you if your cursor is on the first character, you can also just do `dw` (delete word), which is even shorter. 

Say, you want to rebase the last 3 local commits into 1 logical commit, you do a `git rebase -i HEAD~3`, then typically you see something like the following:
```
pick 1c98eb1 1st commit message
pick 1c98eb2 2nd commit message
pick 1c98eb3 3rd commit message
```

And you may want to merge this 3 commits into 1 commit but only keep the 1st commit's message. Then you should edit the rebase as following:
```
pick 1c98eb1 1st commit message
f 1c98eb2 2nd commit message
f 1c98eb3 3rd commit message
```

When changing from `pick` to `f`, you can use `dw` or `diw` to delete `pick` and then add `f`.