### PR TITLE
Add syntax command in Vim

### DIFF
--- a/vim.md
+++ b/vim.md
@@ -6,6 +6,12 @@ Open Vim to a specific line, e.g. line 42:
 
     vim +42 myFile
 
+## Highlight
+
+| Command                     | Description                           |
+| :-------------------------- | :------------------------------------ |
+| `:set syntax=html`          | Highlight as `HTML`                   |
+
 ## Navigation
 | Command                     | Description                           |
 | :-------------------------- | :------------------------------------ |


### PR DESCRIPTION
Useful when Vim failed to highlight your file as a target language. For example, [FreeMarker](https://freemarker.apache.org/) templates `*.ftl` do not have their own highlight syntax, set it to HTML `syntax=html` makes it works.